### PR TITLE
Add recovery module without storage layer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 node_modules/
 dist/
 *.js
+!prebuild.js
 yarn-error.log
 .DS_Store

--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ yarn lint
 yarn eg:gen-evm-addrs
 yarn eg:gen-autoid
 yarn eg:gen-auto-wallet
+yarn eg:sss
+yarn eg:e2e-seed-recovery
 ```
 
 ## Clean Output files

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,7 +1,0 @@
-declare module "shamir-secret-sharing" {
-  export function split(
-    secret: Buffer,
-    options: { shares: number; threshold: number }
-  ): Buffer[];
-  export function combine(shares: Buffer[]): Buffer;
-}

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,7 @@
+declare module "shamir-secret-sharing" {
+  export function split(
+    secret: Buffer,
+    options: { shares: number; threshold: number }
+  ): Buffer[];
+  export function combine(shares: Buffer[]): Buffer;
+}

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "clean:all": "rm -rf dist && rm -rf node_modules",
     "start": "tsc && node dist/index.js",
     "lint": "eslint . --ext .ts",
+    "format": "prettier --write \"src/**/*.ts\" \"tests/**/*.ts\"",
     "eg:gen-evm-addrs": "tsc && node dist/examples/genEvmAddrs.js",
     "eg:gen-auto-id": "tsc && node dist/examples/genAutoId.js",
     "eg:gen-auto-wallet": "tsc && node dist/examples/genAutoWallet.js",
@@ -24,6 +25,7 @@
     "@typescript-eslint/parser": "^6.13.1",
     "eslint": "^8.55.0",
     "jest": "^29.7.0",
+    "prettier": "^3.1.0",
     "ts-jest": "^29.1.1",
     "typescript": "^5.3.2"
   },
@@ -31,6 +33,6 @@
     "@polkadot/api": "^10.11.1",
     "@semaphore-protocol/identity": "^3.15.1",
     "ethers": "^6.9.0",
-    "shamir-secret-sharing": "https://github.com/privy-io/shamir-secret-sharing"
+    "shamir-secret-sharing": "https://github.com/abhi3700/shamir-secret-sharing#d5f2fe6f187d5b1aeefd7d258885504d2ff07e6d"
   }
 }

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "lint": "eslint . --ext .ts",
     "eg:gen-evm-addrs": "tsc && node dist/examples/genEvmAddrs.js",
     "eg:gen-auto-id": "tsc && node dist/examples/genAutoId.js",
-    "eg:gen-auto-wallet": "tsc && node dist/examples/genAutoWallet.js"
+    "eg:gen-auto-wallet": "tsc && node dist/examples/genAutoWallet.js",
+    "eg:sss": "tsc && node dist/examples/sss.js"
   },
   "keywords": [],
   "author": "",
@@ -28,6 +29,7 @@
   "dependencies": {
     "@polkadot/api": "^10.11.1",
     "@semaphore-protocol/identity": "^3.15.1",
-    "ethers": "^6.9.0"
+    "ethers": "^6.9.0",
+    "shamir-secret-sharing": "https://github.com/privy-io/shamir-secret-sharing"
   }
 }

--- a/package.json
+++ b/package.json
@@ -15,8 +15,7 @@
     "eg:gen-auto-id": "tsc && node dist/examples/genAutoId.js",
     "eg:gen-auto-wallet": "tsc && node dist/examples/genAutoWallet.js",
     "eg:sss": "tsc && node dist/examples/sss.js",
-    "eg:e2e-seed-recovery": "tsc && node dist/examples/e2eSeedRecovery.js",
-    "eg:rn-storage": "tsc && node dist/examples/rnStorage.js"
+    "eg:e2e-seed-recovery": "tsc && node dist/examples/e2eSeedRecovery.js"
   },
   "keywords": [],
   "author": "",
@@ -35,7 +34,6 @@
     "@polkadot/api": "^10.11.1",
     "@semaphore-protocol/identity": "^3.15.1",
     "ethers": "^6.9.0",
-    "rn-secure-storage": "https://github.com/circuitid/rn-secure-storage#4773a08e483f177b61108287e87ac96f3102831e",
     "shamir-secret-sharing": "https://github.com/abhi3700/shamir-secret-sharing#d5f2fe6f187d5b1aeefd7d258885504d2ff07e6d"
   }
 }

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "start": "tsc && node dist/index.js",
     "lint": "eslint . --ext .ts",
     "format": "prettier --write \"src/**/*.ts\" \"tests/**/*.ts\"",
+    "eg:all": "tsc && node dist/examples/genEvmAddrs.js && node dist/examples/genAutoId.js && node dist/examples/genAutoWallet.js && node dist/examples/sss.js && node dist/examples/e2eSeedRecovery.js",
     "eg:gen-evm-addrs": "tsc && node dist/examples/genEvmAddrs.js",
     "eg:gen-auto-id": "tsc && node dist/examples/genAutoId.js",
     "eg:gen-auto-wallet": "tsc && node dist/examples/genAutoWallet.js",
@@ -34,6 +35,6 @@
     "@polkadot/api": "^10.11.1",
     "@semaphore-protocol/identity": "^3.15.1",
     "ethers": "^6.9.0",
-    "shamir-secret-sharing": "https://github.com/abhi3700/shamir-secret-sharing#d5f2fe6f187d5b1aeefd7d258885504d2ff07e6d"
+    "shamir-secret-sharing": "https://github.com/privy-io/shamir-secret-sharing"
   }
 }

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
+    "postinstall": "node prebuild.js",
     "build": "tsc",
     "clean": "rm -rf dist",
     "clean:all": "rm -rf dist && rm -rf node_modules",
@@ -14,7 +15,8 @@
     "eg:gen-auto-id": "tsc && node dist/examples/genAutoId.js",
     "eg:gen-auto-wallet": "tsc && node dist/examples/genAutoWallet.js",
     "eg:sss": "tsc && node dist/examples/sss.js",
-    "eg:e2e-seed-recovery": "tsc && node dist/examples/e2eSeedRecovery.js"
+    "eg:e2e-seed-recovery": "tsc && node dist/examples/e2eSeedRecovery.js",
+    "eg:rn-storage": "tsc && node dist/examples/rnStorage.js"
   },
   "keywords": [],
   "author": "",
@@ -33,6 +35,7 @@
     "@polkadot/api": "^10.11.1",
     "@semaphore-protocol/identity": "^3.15.1",
     "ethers": "^6.9.0",
+    "rn-secure-storage": "https://github.com/circuitid/rn-secure-storage#4773a08e483f177b61108287e87ac96f3102831e",
     "shamir-secret-sharing": "https://github.com/abhi3700/shamir-secret-sharing#d5f2fe6f187d5b1aeefd7d258885504d2ff07e6d"
   }
 }

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "eg:gen-evm-addrs": "tsc && node dist/examples/genEvmAddrs.js",
     "eg:gen-auto-id": "tsc && node dist/examples/genAutoId.js",
     "eg:gen-auto-wallet": "tsc && node dist/examples/genAutoWallet.js",
-    "eg:sss": "tsc && node dist/examples/sss.js"
+    "eg:sss": "tsc && node dist/examples/sss.js",
+    "eg:e2e-seed-recovery": "tsc && node dist/examples/e2eSeedRecovery.js"
   },
   "keywords": [],
   "author": "",

--- a/prebuild.js
+++ b/prebuild.js
@@ -1,0 +1,13 @@
+const { exec } = require("child_process");
+
+exec(
+  "cd ./node_modules/shamir-secret-sharing && yarn build && cd ../../",
+  (error, stdout, stderr) => {
+    if (error) {
+      console.error(`exec error: ${error}`);
+      return;
+    }
+    console.log(`stdout: ${stdout}`);
+    console.error(`stderr: ${stderr}`);
+  }
+);

--- a/src/examples/e2eSeedRecovery.ts
+++ b/src/examples/e2eSeedRecovery.ts
@@ -1,7 +1,10 @@
 import { getRandom10Shares } from "../lib/utils";
-import { generateSssSharesFrom, recoverSeedFrom } from "../lib/recovery";
+import {
+  generateSssSharesFrom,
+  recoverSeedFrom,
+  NUM_OF_SHARES,
+} from "../lib/recovery";
 import assert from "assert";
-import { NUM_OF_SHARES } from "../lib/recovery";
 
 async function main() {
   const seedPhrase =
@@ -11,17 +14,17 @@ async function main() {
 
   // select any random 10 shares
   const randomShares: Uint8Array[] = getRandom10Shares(shares);
-  const randomSharesBuffers: Buffer[] = randomShares.map((share) =>
-    Buffer.from(share),
-  );
+  // const randomSharesBuffers: Buffer[] = randomShares.map((share) =>
+  //   Buffer.from(share)
+  // );
 
   // recover seed phrase from random shares
-  const recoveredSeedPhrase = await recoverSeedFrom(randomSharesBuffers);
+  const recoveredSeedPhrase = await recoverSeedFrom(randomShares);
 
   assert.strictEqual(
     recoveredSeedPhrase,
     seedPhrase,
-    "Recovered seed phrase does not match the original seed phrase",
+    "Recovered seed phrase does not match the original seed phrase"
   );
 }
 

--- a/src/examples/e2eSeedRecovery.ts
+++ b/src/examples/e2eSeedRecovery.ts
@@ -1,0 +1,27 @@
+import { getRandom10Shares } from "../lib/utils";
+import { generateSssSharesFrom, recoverSeedFrom } from "../lib/recovery";
+import assert from "assert";
+import { NUM_OF_SHARES } from "../lib/recovery";
+
+async function main() {
+  const seedPhrase =
+    "lock frost nation imitate party medal knee cigar rough wine document immense";
+  const shares = await generateSssSharesFrom(seedPhrase);
+  assert.equal(shares.length, NUM_OF_SHARES);
+
+  // select any random 10 shares
+  const randomShares = getRandom10Shares(shares);
+
+  // recover seed phrase from random shares
+  const recoveredSeedPhrase = await recoverSeedFrom(randomShares);
+
+  assert.strictEqual(
+    recoveredSeedPhrase,
+    seedPhrase,
+    "Recovered seed phrase does not match the original seed phrase"
+  );
+}
+
+main()
+  .catch((err) => console.error(err))
+  .finally(() => process.exit(0));

--- a/src/examples/e2eSeedRecovery.ts
+++ b/src/examples/e2eSeedRecovery.ts
@@ -24,7 +24,7 @@ async function main() {
   assert.strictEqual(
     recoveredSeedPhrase,
     seedPhrase,
-    "Recovered seed phrase does not match the original seed phrase"
+    "Recovered seed phrase does not match the original seed phrase",
   );
 }
 

--- a/src/examples/e2eSeedRecovery.ts
+++ b/src/examples/e2eSeedRecovery.ts
@@ -7,6 +7,7 @@ import {
 import assert from "assert";
 
 async function main() {
+  console.log("\n=======E2E Seed Recovery========");
   const seedPhrase =
     "lock frost nation imitate party medal knee cigar rough wine document immense";
   const shares = await generateSssSharesFrom(seedPhrase);
@@ -14,9 +15,6 @@ async function main() {
 
   // select any random 10 shares
   const randomShares: Uint8Array[] = getRandom10Shares(shares);
-  // const randomSharesBuffers: Buffer[] = randomShares.map((share) =>
-  //   Buffer.from(share)
-  // );
 
   // recover seed phrase from random shares
   const recoveredSeedPhrase = await recoverSeedFrom(randomShares);

--- a/src/examples/e2eSeedRecovery.ts
+++ b/src/examples/e2eSeedRecovery.ts
@@ -10,15 +10,18 @@ async function main() {
   assert.equal(shares.length, NUM_OF_SHARES);
 
   // select any random 10 shares
-  const randomShares = getRandom10Shares(shares);
+  const randomShares: Uint8Array[] = getRandom10Shares(shares);
+  const randomSharesBuffers: Buffer[] = randomShares.map((share) =>
+    Buffer.from(share),
+  );
 
   // recover seed phrase from random shares
-  const recoveredSeedPhrase = await recoverSeedFrom(randomShares);
+  const recoveredSeedPhrase = await recoverSeedFrom(randomSharesBuffers);
 
   assert.strictEqual(
     recoveredSeedPhrase,
     seedPhrase,
-    "Recovered seed phrase does not match the original seed phrase"
+    "Recovered seed phrase does not match the original seed phrase",
   );
 }
 

--- a/src/examples/genAutoId.ts
+++ b/src/examples/genAutoId.ts
@@ -5,6 +5,7 @@
 import { getAutoIdFromSeed } from "../index";
 
 function main() {
+  console.log("\n=======Generate Auto ID from seed phrase========");
   const seedPhrase =
     "lock frost nation imitate party medal knee cigar rough wine document immense";
   console.log("Seed phrase:", seedPhrase);

--- a/src/examples/genAutoWallet.ts
+++ b/src/examples/genAutoWallet.ts
@@ -6,6 +6,9 @@ import { generateAutoWallet } from "../index";
 import { cryptoWaitReady } from "@polkadot/util-crypto";
 
 async function main() {
+  console.log(
+    "\n=======Generate Auto Wallet (Unified Subspace account)========",
+  );
   await cryptoWaitReady(); // Wait for WASM crypto initialization
   const novaEvmDomainRpcApiUrl = "https://nova.gemini-3g.subspace.network/ws";
   const autoWallet = await generateAutoWallet(novaEvmDomainRpcApiUrl, 5);

--- a/src/examples/genAutoWallet.ts
+++ b/src/examples/genAutoWallet.ts
@@ -14,4 +14,6 @@ async function main() {
   console.log("Auto ID:", autoWallet.autoId);
 }
 
-main();
+main()
+  .catch(console.error)
+  .finally(() => process.exit());

--- a/src/examples/genEvmAddrs.ts
+++ b/src/examples/genEvmAddrs.ts
@@ -5,6 +5,8 @@
 import { generateEvmAddressesFromSeed } from "../index";
 
 function main() {
+  console.log("\n=======Generate EVM addresses from seed phrase========");
+
   const seedPhrase =
     "lock frost nation imitate party medal knee cigar rough wine document immense";
   console.log("Seed phrase:", seedPhrase);

--- a/src/examples/sss.ts
+++ b/src/examples/sss.ts
@@ -59,6 +59,7 @@ async function splitSymmetricKey() {
 }
 
 async function main() {
+  console.log("\n=======SSS Examples========");
   await splitUserInput();
   await splitRandomEntropy();
   await splitSymmetricKey();

--- a/src/examples/sss.ts
+++ b/src/examples/sss.ts
@@ -1,0 +1,69 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
+// NOTE: As the `shamir-secret-sharing` package is not yet published, we need to add
+// this file: `index.d.ts` (copy from `shamir-secret-sharing` package) to root folder
+// of this project.
+import { split, combine } from "shamir-secret-sharing";
+import assert from "assert";
+import crypto from "crypto";
+import { toUint8Array } from "../lib/utils";
+
+/// Example of splitting user input
+async function splitUserInput() {
+  const seedPhrase =
+    "lock frost nation imitate party medal knee cigar rough wine document immense";
+  const secret = toUint8Array(seedPhrase);
+  const [share1, share2, share3] = await split(secret, 255, 2);
+
+  const reconstructed = await combine([share1, share3]);
+
+  assert.strictEqual(
+    Buffer.from(reconstructed).toString("base64"),
+    Buffer.from(secret).toString("base64"),
+    "Reconstructed secret does not match the original secret"
+  );
+}
+
+/// Example of splitting random entropy
+async function splitRandomEntropy() {
+  const randomEntropy = crypto.getRandomValues(new Uint8Array(16));
+  const [share1, share2, share3] = await split(randomEntropy, 3, 2);
+  const reconstructed = await combine([share2, share3]);
+
+  assert.strictEqual(
+    Buffer.from(reconstructed).toString("base64"),
+    Buffer.from(randomEntropy).toString("base64"),
+    "Reconstructed secret does not match the original random entropy"
+  );
+}
+
+// Example of splitting symmetric key
+async function splitSymmetricKey() {
+  const key = await crypto.subtle.generateKey(
+    {
+      name: "AES-GCM",
+      length: 256,
+    },
+    true,
+    ["encrypt", "decrypt"]
+  );
+  const exportedKeyBuffer = await crypto.subtle.exportKey("raw", key);
+  const exportedKey = new Uint8Array(exportedKeyBuffer);
+  const [share1, share2, share3] = await split(exportedKey, 3, 2);
+  const reconstructed = await combine([share2, share1]);
+
+  assert.strictEqual(
+    Buffer.from(reconstructed).toString("base64"),
+    Buffer.from(exportedKey).toString("base64"),
+    "Reconstructed secret does not match the original exported key"
+  );
+}
+
+async function main() {
+  await splitUserInput();
+  await splitRandomEntropy();
+  await splitSymmetricKey();
+}
+
+main()
+  .catch(console.error)
+  .finally(() => process.exit());

--- a/src/examples/sss.ts
+++ b/src/examples/sss.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
-// NOTE: As the `shamir-secret-sharing` package is not yet published, we need to add
-// this file: `index.d.ts` (copy from `shamir-secret-sharing` package) to root folder
-// of this project.
+// NOTE: As the `shamir-secret-sharing` package is not yet published,
+// `index.d.ts` file needs to be generated during `$ yarn` or `$ yarn install`
+// in the root folder
 import { split, combine } from "shamir-secret-sharing";
 import assert from "assert";
 import crypto from "crypto";
@@ -12,33 +12,27 @@ async function splitUserInput() {
   const seedPhrase =
     "lock frost nation imitate party medal knee cigar rough wine document immense";
   const secret = toUint8Array(seedPhrase);
-  const [share1, share2, share3] = await split(Buffer.from(secret), {
-    shares: 3,
-    threshold: 2,
-  });
+  const [share1, share2, share3] = await split(secret, 3, 2);
 
   const reconstructed = await combine([share1, share3]);
 
   assert.strictEqual(
     Buffer.from(reconstructed).toString("base64"),
     Buffer.from(secret).toString("base64"),
-    "Reconstructed secret does not match the original secret",
+    "Reconstructed secret does not match the original secret"
   );
 }
 
 /// Example of splitting random entropy
 async function splitRandomEntropy() {
   const randomEntropy = crypto.getRandomValues(new Uint8Array(16));
-  const [share1, share2, share3] = await split(Buffer.from(randomEntropy), {
-    shares: 3,
-    threshold: 2,
-  });
+  const [share1, share2, share3] = await split(randomEntropy, 3, 2);
   const reconstructed = await combine([share2, share3]);
 
   assert.strictEqual(
     Buffer.from(reconstructed).toString("base64"),
     Buffer.from(randomEntropy).toString("base64"),
-    "Reconstructed secret does not match the original random entropy",
+    "Reconstructed secret does not match the original random entropy"
   );
 }
 
@@ -50,20 +44,17 @@ async function splitSymmetricKey() {
       length: 256,
     },
     true,
-    ["encrypt", "decrypt"],
+    ["encrypt", "decrypt"]
   );
   const exportedKeyBuffer = await crypto.subtle.exportKey("raw", key);
   const exportedKey = new Uint8Array(exportedKeyBuffer);
-  const [share1, share2, share3] = await split(Buffer.from(exportedKey), {
-    shares: 3,
-    threshold: 2,
-  });
+  const [share1, share2, share3] = await split(exportedKey, 3, 2);
   const reconstructed = await combine([share2, share1]);
 
   assert.strictEqual(
     Buffer.from(reconstructed).toString("base64"),
     Buffer.from(exportedKey).toString("base64"),
-    "Reconstructed secret does not match the original exported key",
+    "Reconstructed secret does not match the original exported key"
   );
 }
 

--- a/src/examples/sss.ts
+++ b/src/examples/sss.ts
@@ -19,7 +19,7 @@ async function splitUserInput() {
   assert.strictEqual(
     Buffer.from(reconstructed).toString("base64"),
     Buffer.from(secret).toString("base64"),
-    "Reconstructed secret does not match the original secret"
+    "Reconstructed secret does not match the original secret",
   );
 }
 
@@ -32,7 +32,7 @@ async function splitRandomEntropy() {
   assert.strictEqual(
     Buffer.from(reconstructed).toString("base64"),
     Buffer.from(randomEntropy).toString("base64"),
-    "Reconstructed secret does not match the original random entropy"
+    "Reconstructed secret does not match the original random entropy",
   );
 }
 
@@ -44,7 +44,7 @@ async function splitSymmetricKey() {
       length: 256,
     },
     true,
-    ["encrypt", "decrypt"]
+    ["encrypt", "decrypt"],
   );
   const exportedKeyBuffer = await crypto.subtle.exportKey("raw", key);
   const exportedKey = new Uint8Array(exportedKeyBuffer);
@@ -54,7 +54,7 @@ async function splitSymmetricKey() {
   assert.strictEqual(
     Buffer.from(reconstructed).toString("base64"),
     Buffer.from(exportedKey).toString("base64"),
-    "Reconstructed secret does not match the original exported key"
+    "Reconstructed secret does not match the original exported key",
   );
 }
 

--- a/src/examples/sss.ts
+++ b/src/examples/sss.ts
@@ -12,27 +12,33 @@ async function splitUserInput() {
   const seedPhrase =
     "lock frost nation imitate party medal knee cigar rough wine document immense";
   const secret = toUint8Array(seedPhrase);
-  const [share1, share2, share3] = await split(secret, 255, 2);
+  const [share1, share2, share3] = await split(Buffer.from(secret), {
+    shares: 3,
+    threshold: 2,
+  });
 
   const reconstructed = await combine([share1, share3]);
 
   assert.strictEqual(
     Buffer.from(reconstructed).toString("base64"),
     Buffer.from(secret).toString("base64"),
-    "Reconstructed secret does not match the original secret"
+    "Reconstructed secret does not match the original secret",
   );
 }
 
 /// Example of splitting random entropy
 async function splitRandomEntropy() {
   const randomEntropy = crypto.getRandomValues(new Uint8Array(16));
-  const [share1, share2, share3] = await split(randomEntropy, 3, 2);
+  const [share1, share2, share3] = await split(Buffer.from(randomEntropy), {
+    shares: 3,
+    threshold: 2,
+  });
   const reconstructed = await combine([share2, share3]);
 
   assert.strictEqual(
     Buffer.from(reconstructed).toString("base64"),
     Buffer.from(randomEntropy).toString("base64"),
-    "Reconstructed secret does not match the original random entropy"
+    "Reconstructed secret does not match the original random entropy",
   );
 }
 
@@ -44,17 +50,20 @@ async function splitSymmetricKey() {
       length: 256,
     },
     true,
-    ["encrypt", "decrypt"]
+    ["encrypt", "decrypt"],
   );
   const exportedKeyBuffer = await crypto.subtle.exportKey("raw", key);
   const exportedKey = new Uint8Array(exportedKeyBuffer);
-  const [share1, share2, share3] = await split(exportedKey, 3, 2);
+  const [share1, share2, share3] = await split(Buffer.from(exportedKey), {
+    shares: 3,
+    threshold: 2,
+  });
   const reconstructed = await combine([share2, share1]);
 
   assert.strictEqual(
     Buffer.from(reconstructed).toString("base64"),
     Buffer.from(exportedKey).toString("base64"),
-    "Reconstructed secret does not match the original exported key"
+    "Reconstructed secret does not match the original exported key",
   );
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,4 @@
 export * from "./lib/wallet";
 export * from "./lib/did";
+export * from "./lib/recovery";
+export * from "./lib/utils";

--- a/src/lib/did.ts
+++ b/src/lib/did.ts
@@ -5,14 +5,14 @@
 import { Identity } from "@semaphore-protocol/identity";
 
 /**
- * Generate Auto ID from a seed phrase
+ * Generate Auto ID (identity secret) from a seed phrase
  *
  * @param seedPhrase seed phrase to generate the Auto ID (deterministic)
- * @returns Semaphore commitment i.e. Auto ID
+ * @returns Semaphore Identity secret (trapdoor & nullifier) i.e. Auto ID
  */
 export function getAutoIdFromSeed(seedPhrase: string): string | bigint {
   const identity = new Identity(seedPhrase);
-  return identity.commitment.toString();
+  return identity.secret.toString();
 }
 
 /**

--- a/src/lib/recovery.ts
+++ b/src/lib/recovery.ts
@@ -17,25 +17,28 @@
  */
 
 import { split, combine } from "shamir-secret-sharing";
-import { toUint8Array, encode, decode } from "./utils";
+import { toUint8Array, Uint8ArrayToAsciiString } from "./utils";
 
-const NUM_OF_SHARES = 255;
-const THRESHOLD = 10;
+export const NUM_OF_SHARES = 255;
+export const THRESHOLD = 10;
 
 /**
  * Write shares to IPFS peers
  *
  * @param shares The SSS shares
  */
-async function writeToIpfs(shares: string[]) {}
+// async function writeToIpfs(rpcApiUrl: string, shares: string[]) {}
 
 /**
  * Read shares from IPFS peers
  * @param shares The SSS shares
  */
-async function readFromIpfs(shares: string[]): Promise<string> {
-  return "";
-}
+// async function readFromIpfs(
+//   rpcApiUrl: string,
+//   shares: string[]
+// ): Promise<string> {
+//   return "";
+// }
 
 /**
  * Generate SSS shares from a seed phrase
@@ -51,10 +54,15 @@ export async function generateSssSharesFrom(
   const secret = toUint8Array(seedPhrase);
   const shares = await split(secret, NUM_OF_SHARES, THRESHOLD);
 
-  // const sharesAsBase64 = encode(shares);
+  // NOTE: Base64 encoding or toString not used as there was an issue related to different size of shares
+  // during encoding/conversion. Hence, needed to pad the shares to the same length. So, we don't use either.
+  // Now, the shares can be stored as is in IPFS.
 
-  // TODO: write shares (as base64 string) to IPFS peers
-  // writeToIpfs(sharesAsBase64);
+  // TODO: write/distribute shares (as base64 string) to IPFS peers
+  // writeToIpfs(sharesAsString);
+
+  // Then, we need to maintain a lookup table (p2p DB) of the CID of the shares
+  // for the user to retrieve the shares from IPFS peers.
 
   return shares;
 }
@@ -63,19 +71,20 @@ export async function generateSssSharesFrom(
  * Recover seed phrase from SSS shares
  *
  * @param shares The SSS shares at least 10 shares
- * @returns The seed phrase
+ * @returns The reconstructed seed phrase as ASCII string
  */
 export async function recoverSeedFrom(shares: Uint8Array[]): Promise<string> {
   if (shares.length < 10) {
     throw new Error(`At least ${THRESHOLD} shares are required for recovery`);
   }
-
-  // TODO: read shares (as base64 string) from IPFS peers
-  // const sharesAsBase64 = await readFromIpfs()
-  // const shares = decode(sharesAsBase64);
+  // TODO: read/retrieve/fetch shares (string) from IPFS peers
+  // const shares = await readFromIpfs()
 
   // reconstruct the secret
   const reconstructedSeedPhrase = await combine(shares);
 
-  return reconstructedSeedPhrase.toString();
+  // Convert Uint8Array to ASCII string
+  const seedPhrase = Uint8ArrayToAsciiString(reconstructedSeedPhrase);
+
+  return seedPhrase;
 }

--- a/src/lib/recovery.ts
+++ b/src/lib/recovery.ts
@@ -1,7 +1,7 @@
-/* eslint-disable @typescript-eslint/no-unused-vars */
 /**
  * Seed Recovery using Threshold schemes like Shamir's Secret Sharing (SSS)
- * Breaks a seed phrase into shares and distributes them to IPFS peers.
+ * that breaks a seed phrase into shares and distributes them to either
+ * p2p (non-trusted) or friends (trusted) setup.
  * The shares can be recovered to reconstruct the seed phrase.
  *
  * As it's a GF(2^8) scheme, the shares count can be of:
@@ -23,24 +23,6 @@ export const NUM_OF_SHARES = 255;
 export const THRESHOLD = 10;
 
 /**
- * Write shares to IPFS peers
- *
- * @param shares The SSS shares
- */
-// async function writeToIpfs(rpcApiUrl: string, shares: string[]) {}
-
-/**
- * Read shares from IPFS peers
- * @param shares The SSS shares
- */
-// async function readFromIpfs(
-//   rpcApiUrl: string,
-//   shares: string[]
-// ): Promise<string> {
-//   return "";
-// }
-
-/**
  * Generate SSS shares from a seed phrase
  *
  * @param seedPhrase The seed phrase
@@ -49,20 +31,16 @@ export const THRESHOLD = 10;
 export async function generateSssSharesFrom(
   seedPhrase: string
 ): Promise<Uint8Array[]> {
-  // TODO: const shares = sss.splitSecret(seedPhrase, {
+  // TODO:
   // convert to 8-bit bytes i.e. byte array
   const secret = toUint8Array(seedPhrase);
   const shares = await split(secret, NUM_OF_SHARES, THRESHOLD);
 
   // NOTE: Base64 encoding or toString not used as there was an issue related to different size of shares
-  // during encoding/conversion. Hence, needed to pad the shares to the same length. So, we don't use either.
-  // Now, the shares can be stored as is in IPFS.
+  // during encoding/conversion. Thereby, needed to pad the shares to the same length. So, we don't use either.
 
-  // TODO: write/distribute shares (as base64 string) to IPFS peers
-  // writeToIpfs(sharesAsString);
-
-  // Then, we need to maintain a lookup table (p2p DB) of the CID of the shares
-  // for the user to retrieve the shares from IPFS peers.
+  // TODO: write/distribute shares to trusted/non-trusted setup
+  // Here, we need to maintain a DB that stores the nodes for each user.
 
   return shares;
 }
@@ -70,15 +48,14 @@ export async function generateSssSharesFrom(
 /**
  * Recover seed phrase from SSS shares
  *
- * @param shares The SSS shares at least 10 shares
+ * @param shares The SSS shares at least {THRESHOLD} shares
  * @returns The reconstructed seed phrase as ASCII string
  */
 export async function recoverSeedFrom(shares: Uint8Array[]): Promise<string> {
-  if (shares.length < 10) {
+  if (shares.length < THRESHOLD) {
     throw new Error(`At least ${THRESHOLD} shares are required for recovery`);
   }
-  // TODO: read/retrieve/fetch shares (string) from IPFS peers
-  // const shares = await readFromIpfs()
+  // TODO: read/retrieve/fetch shares (string) from trusted/non-trusted setup
 
   // reconstruct the secret
   const reconstructedSeedPhrase = await combine(shares);

--- a/src/lib/recovery.ts
+++ b/src/lib/recovery.ts
@@ -1,0 +1,81 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
+/**
+ * Seed Recovery using Threshold schemes like Shamir's Secret Sharing (SSS)
+ * Breaks a seed phrase into shares and distributes them to IPFS peers.
+ * The shares can be recovered to reconstruct the seed phrase.
+ *
+ * As it's a GF(2^8) scheme, the shares count can be of:
+ * - Maximum shares: 255
+ * - Minimum shares: 2
+ *
+ * Here,
+ * - no. of shares = 255 (max. 'n' used to ensure at least 'k' nodes availability).
+ * - threshold = 10 (not too low like 2 (min) where both could collate & retrieve the secret).
+ *
+ *
+ * More on this: https://www.notion.so/subspacelabs/Account-Recovery-Technical-c9a23398a96b4c7c999ba1e239479b8d#1c8f8e2ca12345b6b080e591525487eb
+ */
+
+import { split, combine } from "shamir-secret-sharing";
+import { toUint8Array, encode, decode } from "./utils";
+
+const NUM_OF_SHARES = 255;
+const THRESHOLD = 10;
+
+/**
+ * Write shares to IPFS peers
+ *
+ * @param shares The SSS shares
+ */
+async function writeToIpfs(shares: string[]) {}
+
+/**
+ * Read shares from IPFS peers
+ * @param shares The SSS shares
+ */
+async function readFromIpfs(shares: string[]): Promise<string> {
+  return "";
+}
+
+/**
+ * Generate SSS shares from a seed phrase
+ *
+ * @param seedPhrase The seed phrase
+ * @returns The SSS shares
+ */
+export async function generateSssSharesFrom(
+  seedPhrase: string
+): Promise<Uint8Array[]> {
+  // TODO: const shares = sss.splitSecret(seedPhrase, {
+  // convert to 8-bit bytes i.e. byte array
+  const secret = toUint8Array(seedPhrase);
+  const shares = await split(secret, NUM_OF_SHARES, THRESHOLD);
+
+  // const sharesAsBase64 = encode(shares);
+
+  // TODO: write shares (as base64 string) to IPFS peers
+  // writeToIpfs(sharesAsBase64);
+
+  return shares;
+}
+
+/**
+ * Recover seed phrase from SSS shares
+ *
+ * @param shares The SSS shares at least 10 shares
+ * @returns The seed phrase
+ */
+export async function recoverSeedFrom(shares: Uint8Array[]): Promise<string> {
+  if (shares.length < 10) {
+    throw new Error(`At least ${THRESHOLD} shares are required for recovery`);
+  }
+
+  // TODO: read shares (as base64 string) from IPFS peers
+  // const sharesAsBase64 = await readFromIpfs()
+  // const shares = decode(sharesAsBase64);
+
+  // reconstruct the secret
+  const reconstructedSeedPhrase = await combine(shares);
+
+  return reconstructedSeedPhrase.toString();
+}

--- a/src/lib/recovery.ts
+++ b/src/lib/recovery.ts
@@ -29,7 +29,7 @@ export const THRESHOLD = 10;
  * @returns The SSS shares
  */
 export async function generateSssSharesFrom(
-  seedPhrase: string
+  seedPhrase: string,
 ): Promise<Uint8Array[]> {
   // TODO:
   // convert to 8-bit bytes i.e. byte array

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -61,7 +61,7 @@ export function getRandom10Shares(shares: Uint8Array[]): Uint8Array[] {
   assert.equal(
     randomShares.length,
     THRESHOLD,
-    "Random shares length is not 10"
+    `Random shares length is not ${THRESHOLD}`
   );
 
   return randomShares;

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -61,7 +61,7 @@ export function getRandom10Shares(shares: Uint8Array[]): Uint8Array[] {
   assert.equal(
     randomShares.length,
     THRESHOLD,
-    `Random shares length is not ${THRESHOLD}`
+    `Random shares length is not ${THRESHOLD}`,
   );
 
   return randomShares;

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,28 +1,68 @@
+import assert from "assert";
+import { THRESHOLD } from "./recovery";
+
 /**
  * Convert string to Uint8Array
- * @param {string} data The string
- * @returns {Uint8Array} The Uint8Array
+ * @param data The string
+ * @returns The Uint8Array
  */
 export function toUint8Array(data: string): Uint8Array {
   return new TextEncoder().encode(data);
 }
 
 /**
- * Encodes the given Uint8Array data into a base64 string.
+ * Converts a Uint8Array to an ASCII string.
  *
- * @param data - The Uint8Array data to be encoded.
- * @returns The base64 encoded string.
+ * @param data - The Uint8Array to convert.
+ * @returns The ASCII string representation of the Uint8Array.
  */
-export function encode(data: Uint8Array): string {
+export function Uint8ArrayToAsciiString(data: Uint8Array): string {
+  return Array.from(data)
+    .map((byte) => String.fromCharCode(byte))
+    .join("");
+}
+
+/**
+ * Encodes the given string using base64 encoding.
+ *
+ * @param data - The string to be encoded.
+ * @returns The encoded string.
+ */
+export function encode(data: string): string {
   return Buffer.from(data).toString("base64");
 }
 
 /**
- * Decodes the given base64 string into a Uint8Array.
+ * Decodes a base64 encoded string.
  *
- * @param encodedData - The base64 encoded string to be decoded.
- * @returns The Uint8Array data.
+ * @param encodedData The base64 encoded string to decode.
+ * @returns The decoded string.
  */
-export function decode(encodedData: string): Uint8Array {
-  return Buffer.from(encodedData, "base64");
+export function decode(encodedData: string): string {
+  return Buffer.from(encodedData, "base64").toString();
+}
+
+/**
+ * Returns an array of 10 randomly selected shares from the given array of shares.
+ * @param shares - The array of shares to select from.
+ * @returns An array of 10 randomly selected shares.
+ */
+export function getRandom10Shares(shares: Uint8Array[]): Uint8Array[] {
+  const randomShares: Uint8Array[] = [];
+  const randomIndices: number[] = [];
+  while (randomIndices.length < THRESHOLD) {
+    const randomIndex = Math.floor(Math.random() * shares.length);
+    if (!randomIndices.includes(randomIndex)) {
+      randomIndices.push(randomIndex);
+      randomShares.push(shares[randomIndex]);
+    }
+  }
+
+  assert.equal(
+    randomShares.length,
+    THRESHOLD,
+    "Random shares length is not 10"
+  );
+
+  return randomShares;
 }

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,0 +1,28 @@
+/**
+ * Convert string to Uint8Array
+ * @param {string} data The string
+ * @returns {Uint8Array} The Uint8Array
+ */
+export function toUint8Array(data: string): Uint8Array {
+  return new TextEncoder().encode(data);
+}
+
+/**
+ * Encodes the given Uint8Array data into a base64 string.
+ *
+ * @param data - The Uint8Array data to be encoded.
+ * @returns The base64 encoded string.
+ */
+export function encode(data: Uint8Array): string {
+  return Buffer.from(data).toString("base64");
+}
+
+/**
+ * Decodes the given base64 string into a Uint8Array.
+ *
+ * @param encodedData - The base64 encoded string to be decoded.
+ * @returns The Uint8Array data.
+ */
+export function decode(encodedData: string): Uint8Array {
+  return Buffer.from(encodedData, "base64");
+}

--- a/src/lib/wallet.ts
+++ b/src/lib/wallet.ts
@@ -1,6 +1,18 @@
 /* eslint-disable no-constant-condition */
 /* eslint-disable @typescript-eslint/no-unused-vars */
 
+/**
+ * Wallet module for Auto.
+ * This module creates
+ * - a new wallet with a random seed phrase with
+ * addresses for relay chain and EVM chains (based on BIP-32) and
+ * an Auto ID (based on Semaphore Identity).
+ * - an unified account with a unique Auto ID (based on Semaphore Identity) added
+ * on-chain to one of the EVM domains (where DID registry is deployed).
+ *
+ * Doc: https://www.notion.so/subspacelabs/Subspace-Unified-Account-Technical-6b73858668984751bc3e10356721990b
+ */
+
 import { Keyring } from "@polkadot/api";
 import { mnemonicGenerate } from "@polkadot/util-crypto";
 import { Mnemonic, ethers } from "ethers";

--- a/src/lib/wallet.ts
+++ b/src/lib/wallet.ts
@@ -28,7 +28,7 @@ import { getAutoIdFromSeed, getIdentityFromSeed } from "./did";
  */
 async function checkIfAutoIdExistsOnChain(
   api: string,
-  seedPhrase: string
+  seedPhrase: string,
 ): Promise<boolean> {
   // TODO: connect to the main EVM domain (where DID registry is deployed)
 
@@ -57,7 +57,7 @@ async function checkIfAutoIdExistsOnChain(
  */
 export function generateEvmAddressesFromSeed(
   seedPhrase: string,
-  numOfAddresses: number
+  numOfAddresses: number,
 ): string[] {
   const addresses: string[] = [];
   const mnemonic = Mnemonic.fromPhrase(seedPhrase); // Convert the seed phrase to mnemonic
@@ -109,7 +109,7 @@ interface AutoWallet {
  */
 export async function generateAutoWallet(
   mainEvmDomainRpcApiUrl: string,
-  numOfEvmChains: number
+  numOfEvmChains: number,
 ): Promise<AutoWallet> {
   let seedPhrase = "";
 
@@ -121,7 +121,7 @@ export async function generateAutoWallet(
     // TODO: Check for a valid Auto ID
     const isAutoIdPreExist = await checkIfAutoIdExistsOnChain(
       mainEvmDomainRpcApiUrl,
-      seedPhrase
+      seedPhrase,
     );
 
     if (!isAutoIdPreExist) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3014,10 +3014,6 @@ rimraf@^3.0.2:
   dependencies:
     glob "^7.1.3"
 
-"rn-secure-storage@https://github.com/circuitid/rn-secure-storage#4773a08e483f177b61108287e87ac96f3102831e":
-  version "2.0.8"
-  resolved "https://github.com/circuitid/rn-secure-storage#4773a08e483f177b61108287e87ac96f3102831e"
-
 run-parallel@^1.1.9:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/run-parallel/-/run-parallel-1.2.0.tgz#66d1368da7bdf921eb9d95bd1a9229e7f21a43ee"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2919,6 +2919,11 @@ prelude-ls@^1.2.1:
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.2.1.tgz#debc6489d7a6e6b0e7611888cec880337d316396"
   integrity sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==
 
+prettier@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-3.1.0.tgz#c6d16474a5f764ea1a4a373c593b779697744d5e"
+  integrity sha512-TQLvXjq5IAibjh8EpBIkNKxO749UEWABoiIZehEPiY4GNpVdhaFKqSTu+QrlU6D2dPAfubRmtJTi4K4YkQ5eXw==
+
 pretty-format@^29.0.0, pretty-format@^29.7.0:
   version "29.7.0"
   resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-29.7.0.tgz#ca42c758310f365bfa71a0bda0a807160b776812"
@@ -3009,6 +3014,10 @@ rimraf@^3.0.2:
   dependencies:
     glob "^7.1.3"
 
+"rn-secure-storage@https://github.com/circuitid/rn-secure-storage#4773a08e483f177b61108287e87ac96f3102831e":
+  version "2.0.8"
+  resolved "https://github.com/circuitid/rn-secure-storage#4773a08e483f177b61108287e87ac96f3102831e"
+
 run-parallel@^1.1.9:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/run-parallel/-/run-parallel-1.2.0.tgz#66d1368da7bdf921eb9d95bd1a9229e7f21a43ee"
@@ -3035,9 +3044,9 @@ semver@^7.5.3, semver@^7.5.4:
   dependencies:
     lru-cache "^6.0.0"
 
-"shamir-secret-sharing@https://github.com/privy-io/shamir-secret-sharing":
+"shamir-secret-sharing@https://github.com/abhi3700/shamir-secret-sharing#d5f2fe6f187d5b1aeefd7d258885504d2ff07e6d":
   version "0.0.3"
-  resolved "https://github.com/privy-io/shamir-secret-sharing#c2220064546ee94c649b6113022a182ee0c49bc0"
+  resolved "https://github.com/abhi3700/shamir-secret-sharing#d5f2fe6f187d5b1aeefd7d258885504d2ff07e6d"
 
 shebang-command@^2.0.0:
   version "2.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3040,9 +3040,9 @@ semver@^7.5.3, semver@^7.5.4:
   dependencies:
     lru-cache "^6.0.0"
 
-"shamir-secret-sharing@https://github.com/abhi3700/shamir-secret-sharing#d5f2fe6f187d5b1aeefd7d258885504d2ff07e6d":
+"shamir-secret-sharing@https://github.com/privy-io/shamir-secret-sharing":
   version "0.0.3"
-  resolved "https://github.com/abhi3700/shamir-secret-sharing#d5f2fe6f187d5b1aeefd7d258885504d2ff07e6d"
+  resolved "https://github.com/privy-io/shamir-secret-sharing#c2220064546ee94c649b6113022a182ee0c49bc0"
 
 shebang-command@^2.0.0:
   version "2.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3035,6 +3035,10 @@ semver@^7.5.3, semver@^7.5.4:
   dependencies:
     lru-cache "^6.0.0"
 
+"shamir-secret-sharing@https://github.com/privy-io/shamir-secret-sharing":
+  version "0.0.3"
+  resolved "https://github.com/privy-io/shamir-secret-sharing#c2220064546ee94c649b6113022a182ee0c49bc0"
+
 shebang-command@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/shebang-command/-/shebang-command-2.0.0.tgz#ccd0af4f8835fbdc265b82461aaf0c36663f34ea"


### PR DESCRIPTION
## Description

This PR adds **recovery** module that is required for recovery of user's seed phrase. 
> The seed phrase is generated when the subspace unified account is created. Please refer PR #1.

The seed is broken into shares using the popular **[Shamir's Secret Sharing (SSS)](https://en.wikipedia.org/wiki/Shamir%27s_secret_sharing)** scheme. Followed by storing via trusted/non-trusted setup. 
> Here, trusted means among known friends. And non-trusted refers to a setup of unknown peers.

This PR does not contain the storage layer, to be used for distribution & retrieval of the shares, but it does feature:
- secret broken into shares
- secret reconstructed from shares

> For PoC, we would have a local DB native to Android/iOS platforms with react native infrastructure. @soufDev would work on this #2.

## Key Changes

- Auto ID changed from Semaphore Identity [commitment to secret](https://github.com/subspace/auto-sdk-ts/pull/3/files#diff-c31eba89cd690978479dd99ded507412c3cd4f712506e6fa804bd4030d8da4b6).
- [`shamir-secret-sharing`](https://github.com/privy-io/shamir-secret-sharing) package added to handle the seed splitting & shares combining mechanisms.
- Added examples to [test run the SSS](https://github.com/abhi3700/auto-sdk-ts/blob/feat/add-recovery/src/examples/sss.ts) and for [end-to-end seed recovery](https://github.com/abhi3700/auto-sdk-ts/blob/feat/add-recovery/src/examples/e2eSeedRecovery.ts).