### PR TITLE
Add Pay on Nova

### DIFF
--- a/packages/sdk/src/examples/getAutoId.ts
+++ b/packages/sdk/src/examples/getAutoId.ts
@@ -1,11 +1,11 @@
 /**
- * Get auto id
+ * Get/Retrieve Auto ID
  */
 
 import { getAutoIdFromSeed } from '../library/did';
 
 function main() {
-  console.log('\n=======Generate Auto ID from seed phrase========');
+  console.log('\n=======Retrieve Auto ID from seed phrase========');
   const seedPhrase =
     'lock frost nation imitate party medal knee cigar rough wine document immense';
   console.log('Seed phrase:', seedPhrase);

--- a/packages/sdk/src/examples/getAutoWallet.ts
+++ b/packages/sdk/src/examples/getAutoWallet.ts
@@ -1,0 +1,21 @@
+/**
+ * Get/Retrieve Auto Wallet (Subspace Unified account/wallet)
+ */
+
+import { getAutoWallet } from '../library/wallet';
+
+async function main() {
+  console.log('\n=======Retrieve Auto Wallet from seed phrase========');
+  const seedPhrase =
+    'lock frost nation imitate party medal knee cigar rough wine document immense';
+  console.log('Seed phrase:', seedPhrase);
+
+  const autoWallet = await getAutoWallet(seedPhrase, 5);
+  console.log('Subspace address:', autoWallet.subspaceAddress);
+  console.log('EVM addresses:', autoWallet.evmAddresses);
+  console.log('Auto ID:', autoWallet.autoId);
+}
+
+main()
+  .catch(console.error)
+  .finally(() => process.exit());

--- a/packages/sdk/src/examples/getEvmAddrs.ts
+++ b/packages/sdk/src/examples/getEvmAddrs.ts
@@ -1,11 +1,11 @@
 /**
- * Generate EVM addresses (following BIP-32) from a seed phrase
+ * Get/Retrieve EVM addresses (following BIP-32) from a seed phrase
  */
 
 import { generateEvmAddressesFromSeed } from '../library/wallet';
 
 function main() {
-  console.log('\n=======Generate EVM addresses from seed phrase========');
+  console.log('\n=======Retrieve EVM addresses from seed phrase========');
 
   const seedPhrase =
     'lock frost nation imitate party medal knee cigar rough wine document immense';

--- a/packages/sdk/src/examples/payOnNova.ts
+++ b/packages/sdk/src/examples/payOnNova.ts
@@ -1,0 +1,20 @@
+/**
+ * Example showing how to pay to an address.
+ */
+
+import { payOnNova } from '../library/pay';
+import { ethers } from 'ethers';
+
+async function main() {
+  console.log('\n=======Send TSSC on Nova========');
+
+  const txHash = await payOnNova(
+    '0x1D1cf575Cc0A8988fA274D36018712dA4632FbDD',
+    ethers.utils.parseEther('0.1')
+  );
+  console.log(`Transaction hash: ${txHash}`);
+}
+
+main()
+  .catch(console.error)
+  .finally(() => process.exit());

--- a/packages/sdk/src/library/pay.ts
+++ b/packages/sdk/src/library/pay.ts
@@ -5,7 +5,16 @@
 import { ethers, BigNumber } from 'ethers';
 import { NOVA_RPC_URL, SIGNER_PRIVATE_KEY } from './constants';
 
-export async function pay(
+/**
+ * Sends a payment transaction on the Nova network.
+ *
+ * @param recipient - The address of the recipient.
+ * @param amount - The amount (in Wei) of the payment.
+ * @param sender - (Optional) The signer of the transaction. If not provided, a new signer will be created using the private key.
+ * @returns A promise that resolves to the transaction hash.
+ * @throws An error if the sender has insufficient balance.
+ */
+export async function payOnNova(
   recipient: string,
   amount: BigNumber,
   sender?: ethers.Signer

--- a/packages/sdk/src/library/pay.ts
+++ b/packages/sdk/src/library/pay.ts
@@ -1,0 +1,40 @@
+/**
+ * Payment module for Auto.
+ */
+
+import { ethers, BigNumber } from 'ethers';
+import { NOVA_RPC_URL, SIGNER_PRIVATE_KEY } from './constants';
+
+export async function pay(
+  recipient: string,
+  amount: BigNumber,
+  sender?: ethers.Signer
+): Promise<string> {
+  // provider/client
+  const provider = new ethers.providers.JsonRpcProvider(NOVA_RPC_URL);
+
+  // get the signer if available
+  sender = sender || new ethers.Wallet(`0x${SIGNER_PRIVATE_KEY}`, provider);
+
+  // Get the balance of the signer
+  const balance = await sender.getBalance();
+
+  const gasPrice = await provider.getGasPrice();
+
+  // Check if the signer has enough balance including required gas
+  if (balance.lt(amount.add(gasPrice.mul(21000)))) {
+    throw new Error('Insufficient balance');
+  }
+
+  // Send the transaction
+  const tx = await sender.sendTransaction({
+    to: recipient,
+    value: amount,
+  });
+
+  // Wait for the transaction to be mined
+  await tx.wait();
+
+  // Return the transaction hash
+  return tx.hash;
+}

--- a/packages/sdk/src/library/wallet.ts
+++ b/packages/sdk/src/library/wallet.ts
@@ -111,12 +111,13 @@ export interface AutoWallet {
 }
 
 /**
- * Generate a new wallet with a random seed
- * returning the SS58 address and the EVM addresses
+ * Generates an AutoWallet with a unique Auto ID and performs various operations related to the wallet.
+ * Random seed is used to generate the addresses for relay chain and EVM chains (based on BIP-32).
  * NOTE: for simplicity, considered only EVM based domains
- *
- * @param numOfEvmChains The number of EVM chains to generate addresses for
- * @returns The [AutoWallet, TxHash] object
+ * 
+ * @param numOfEvmChains The number of EVM chains to generate addresses for.
+ * @returns A promise that resolves to an array containing the generated AutoWallet and the transaction hash.
+ * @throws If an error occurs during Auto account generation.
  */
 export async function generateAutoWallet(
   numOfEvmChains: number
@@ -186,9 +187,11 @@ export async function generateAutoWallet(
 }
 
 /**
- * Checks if the given Auto ID is verified.
- * @param autoId The Auto ID to check.
- * @returns A Promise that resolves to a boolean indicating whether the Auto ID is verified or not.
+ * Verifies if the given AutoId is verified.
+ * 
+ * @param autoId - The AutoId to be verified.
+ * @returns A Promise that resolves to a boolean indicating if the AutoId is verified.
+ * @throws An error if there is an issue verifying the AutoId.
  */
 export async function isAutoIdVerified(
   autoId: string | bigint


### PR DESCRIPTION
## Description

This PR adds payment feature on Nova network.

> The new account should have enough balance & gas fees to send payment to a recipient address.

- Added `payOnNova` function to transfer money to recipient.
- Added `getAutoWallet` function to retrieve the Subspace Unified Account with addresses for all chains (relay + domain).