### PR TITLE
Improved function: retrieve Auto Wallet

### DIFF
--- a/apps/auto-app/app/utils/genAutoWallet.ts
+++ b/apps/auto-app/app/utils/genAutoWallet.ts
@@ -8,12 +8,12 @@ import { cryptoWaitReady } from "@polkadot/util-crypto"
 
 export async function genAutoWallet() {
   await cryptoWaitReady() // Wait for WASM crypto initialization
-  const novaEvmDomainRpcApiUrl = "https://nova.gemini-3g.subspace.network/ws"
-  const autoWallet = await generateAutoWallet(novaEvmDomainRpcApiUrl, 5)
+  const [autoWallet, txHash] = await generateAutoWallet(5)
 
   console.log("Subspace address:", autoWallet.subspaceAddress)
   console.log("EVM addresses:", autoWallet.evmAddresses)
   console.log("Auto ID:", autoWallet.autoId)
+  console.log(`Transaction hash for adding the new user to group: ${txHash}`)
   const recoveredSeedPhrase = await recoverSeedFrom()
   return { ...autoWallet, recoveredSeedPhrase }
 }

--- a/packages/sdk/src/examples/getAutoWallet.ts
+++ b/packages/sdk/src/examples/getAutoWallet.ts
@@ -10,7 +10,7 @@ async function main() {
     'lock frost nation imitate party medal knee cigar rough wine document immense';
   console.log('Seed phrase:', seedPhrase);
 
-  const autoWallet = await getAutoWallet(seedPhrase, 5);
+  const autoWallet = await getAutoWallet(5);
   console.log('Subspace address:', autoWallet.subspaceAddress);
   console.log('EVM addresses:', autoWallet.evmAddresses);
   console.log('Auto ID:', autoWallet.autoId);


### PR DESCRIPTION
## Description

This PR addresses dual way to retrieve Auto Wallet.

1. Without parsing any seed phrase, the recovered seed phrase from local storage DB is used to retrieve the Auto Wallet.
2. If seed phrase is parsed, then it is used to do the same.

In short, `seedPhrase` param is optional in this new version.